### PR TITLE
typo regarding the `Permission` suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Paper identifiers should follow the format `lastnameYY` where `lastname` is the 
 ### Permission Forms
 
 Each author must sign a permission form. The forms should be:
-- Named according to the paper ID with `Permission` suffix (e.g., `reid25a-Permission.pdf`)
-- Placed in a separate directory called `v283permissions`
+- Named according to the paper ID with `Permission` suffix (e.g., `reid25aPermission.pdf`)
+- Placed in a separate directory called `vXpermissions` (e.g., `v283permissions`).
 
 ## Sectioned Proceedings (Optional)
 


### PR DESCRIPTION
Corrects a minor typo in the REAMDE regarding the `Permission` suffix. As per the [FAQ](https://proceedings.mlr.press/faq.html), the permission file "should be named with the convention given above with the suffix `Permission`, e.g. `turner10aPermission.pdf`."